### PR TITLE
fix 0.0.1: jsonp callback parameter name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 
 # production
 dist/
+
+# IDE
+.vscode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonp-es-promise",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Typed jsonp using promise",
   "license": "MIT",
   "author": "cdpark0530",

--- a/src/features.ts
+++ b/src/features.ts
@@ -8,19 +8,27 @@ export interface JsonpResult<R> {
 export interface JsonpOptions {
   params?: string;
   timeout?: number;
-  callbackName?: string;
+  /**
+   * @default "jsonp"
+   */
+  callbackParam?: string;
+  callbackKey?: string;
+  /**
+   * will be ignored if `callbackName` is defined
+   */
   prefix?: string;
 }
 
 export const jsonp = <R>(url: string, options?: JsonpOptions): JsonpResult<R> => {
-  const { params, prefix, timeout, callbackName } = {
+  const { params, prefix, timeout, callbackParam, callbackKey }: JsonpOptions = {
     timeout: 15000,
     params: '__callback',
+    callbackParam: 'jsonp',
     prefix: '__jp',
     ...options,
   };
 
-  const windowVarName = callbackName ?? `${prefix}${callbackCount++}`;
+  const windowVarName = callbackKey ?? `${prefix}${callbackCount++}`;
   let scriptEl: HTMLScriptElement | undefined = undefined;
   let timer: number | undefined = undefined;
 
@@ -64,7 +72,10 @@ export const jsonp = <R>(url: string, options?: JsonpOptions): JsonpResult<R> =>
       url += '?';
     }
 
-    url += `${params}&callback=${encodeURIComponent(windowVarName)}`.replace(/^&+|&+$/g, '');
+    url += `${params}&${callbackParam}=${encodeURIComponent(windowVarName)}`.replace(
+      /^&+|&+$/g,
+      '',
+    );
 
     scriptEl = document.createElement('script');
     scriptEl.src = url;


### PR DESCRIPTION
- The request parameter for servers to identify that this is jsonp request is fixed as `?...&callback=${callbackName}`.
- Depending on servers, the parameter name can be different.
- Provide a way to customize the name.