### PR TITLE
fix 0.0.4: add jQuery interop option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsonp-es-promise",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jsonp-es-promise",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonp-es-promise",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Typed jsonp using promise",
   "license": "MIT",
   "author": "cdpark0530",

--- a/src/features.ts
+++ b/src/features.ts
@@ -9,18 +9,23 @@ export interface JsonpOptions {
   params?: string;
   timeout?: number;
   /**
+   * URL parameter name to tell server jsonp callback name
    * @default "jsonp"
    */
   callbackParam?: string;
-  callbackKey?: string;
+  /**
+   * jsonp callback name
+   */
+  callbackName?: string;
   /**
    * will be ignored if `callbackName` is defined
    */
   prefix?: string;
+  jQueryInterop?: true;
 }
 
 export const jsonp = <R>(url: string, options?: JsonpOptions): JsonpResult<R> => {
-  const { params, prefix, timeout, callbackParam, callbackKey }: JsonpOptions = {
+  const { params, prefix, timeout, callbackParam, callbackName, jQueryInterop }: JsonpOptions = {
     timeout: 15000,
     params: '__callback',
     callbackParam: 'jsonp',
@@ -28,7 +33,7 @@ export const jsonp = <R>(url: string, options?: JsonpOptions): JsonpResult<R> =>
     ...options,
   };
 
-  const windowVarName = callbackKey ?? `${prefix}${callbackCount++}`;
+  const windowVarName = callbackName ?? `${prefix}${callbackCount++}`;
   let scriptEl: HTMLScriptElement | undefined = undefined;
   let timer: number | undefined = undefined;
 
@@ -75,7 +80,6 @@ export const jsonp = <R>(url: string, options?: JsonpOptions): JsonpResult<R> =>
       }, timeout);
     }
 
-
     if (url.indexOf('?') < 0) {
       url += '?';
     } else if (url.indexOf('?') !== url.length - 1) {
@@ -84,6 +88,9 @@ export const jsonp = <R>(url: string, options?: JsonpOptions): JsonpResult<R> =>
 
     const searchParams = new URLSearchParams(params);
     searchParams.append(callbackParam, windowVarName);
+    if (jQueryInterop) {
+      searchParams.append('_', Date.now().toString());
+    }
     url += searchParams.toString();
 
     scriptEl = document.createElement('script');


### PR DESCRIPTION
### Fix background
jsonp can be said to be legacy. There are still legacy systems, and they can depend on jQuery, so their web interface is kinda standardize by jQuery. And jQuery append `_=<timestamp>` query to jsonp requests, so some legacy systems work property only when the query is in request parameters.

### Other changes
- option name: `callbackKey` → `callbackName`